### PR TITLE
range from 0 to  payload.endIndex

### DIFF
--- a/Subtitles.swift
+++ b/Subtitles.swift
@@ -122,7 +122,11 @@ public extension AVPlayerViewController {
             // Get groups
             let regexStr = "(?m)(^[0-9]+)([\\s\\S]*?)(?=\n\n)"
             let regex = try NSRegularExpression(pattern: regexStr, options: .CaseInsensitive)
-            let matches = regex.matchesInString(payload, options: NSMatchingOptions(rawValue: 0), range: NSMakeRange(0, payload.characters.count))
+            
+            let lastIndexStr = String(payload.endIndex)
+            let lastIndexInt = Int(lastIndexStr)
+            
+            let matches = regex.matchesInString(payload, options: NSMatchingOptions(rawValue: 0), range: NSMakeRange(0, lastIndexInt!))
             for m in matches {
                 
                 let group = (payload as NSString).substringWithRange(m.range)


### PR DESCRIPTION
replacing payload.endIndex with payload.characters.count.
because, some subtitles, the ```matches``` count doesn't match the number scripts in the srt file.
