### PR TITLE
Fix regex due to couple timestamp standards

### DIFF
--- a/Subtitles.swift
+++ b/Subtitles.swift
@@ -137,7 +137,7 @@ public extension AVPlayerViewController {
                 let index = (group as NSString).substring(with: i.range)
                 
                 // Get "from" & "to" time
-                regex = try NSRegularExpression(pattern: "\\d{1,2}:\\d{1,2}:\\d{1,2},\\d{1,3}", options: .caseInsensitive)
+                regex = try NSRegularExpression(pattern: "\\d{1,2}:\\d{1,2}:\\d{1,2}[.,]\\d{1,3}", options: .caseInsensitive)
                 match = regex.matches(in: group, options: NSRegularExpression.MatchingOptions(rawValue: 0), range: NSMakeRange(0, group.characters.count))
                 guard match.count == 2 else {
                     continue


### PR DESCRIPTION
Hello,
Thank you for this repo, very helpful.
But I've found an issue with timestamps and your current regex.
In some cases there is some differences:
`00:00:00.935 --> 00:00:02.668`
`00:00:00,935 --> 00:00:02,668`