### PR TITLE
adding support to add Dictionary content to subtitles

### DIFF
--- a/Subtitles.swift
+++ b/Subtitles.swift
@@ -209,7 +209,19 @@ public extension AVPlayerViewController {
         
         // Parse
         parsedPayload = Subtitles.parseSubRip(string)
+        addPeriodicNotification(parsedPayload: parsedPayload!)
         
+    }
+    
+    func showByDictionary(dictionaryContent: NSMutableDictionary) {
+        
+        // Add Dictionary content direct to Payload
+        parsedPayload = dictionaryContent
+        addPeriodicNotification(parsedPayload: parsedPayload!)
+        
+    }
+    
+    func addPeriodicNotification(parsedPayload: NSDictionary) {
         // Add periodic notifications
         self.player?.addPeriodicTimeObserver(
             forInterval: CMTimeMake(1, 60),
@@ -231,10 +243,10 @@ public extension AVPlayerViewController {
                     strongSelf.subtitleLabelHeightConstraint?.constant = rect.height
                 }
                 
-                
         })
         
     }
+
     
     // MARK: - Private methods
     fileprivate func addSubtitleLabel() {


### PR DESCRIPTION
added function showByDictionary that has input NSMutableDictionary to bypass the parsing method srt.

i use this parsing XML from youtube like this:

```
let subtitlesDictionary = NSMutableDictionary()
if CaptionUrl != nil {
    Alamofire.request(CaptionUrl!).response {
        response in

            let xml = SWXMLHash.parse(response.data!)

        var counter = 0
        for elem in xml["transcript"]["text"].all {
            let fromTime = Double((elem.element ? .attribute(by: "start") ? .text) !)
            let toTime = fromTime!+Double((elem.element ? .attribute(by: "dur") ? .text) !) !
            let text = elem.element ? .text

            // Create final object
            let final = NSMutableDictionary()
            final["from"] = fromTime
            final["to"] = toTime
            final["text"] = replacedText
            subtitlesDictionary[counter] = final
            counter += 1
        }
    }
}


// Add subtitles
playerViewController?.addSubtitles().showByDictionary(dictionaryContent: subtitlesDictionary)
```